### PR TITLE
Lowercase `w` for org name for devtools install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ types.
 
 ``` r
 library(devtools)
-install_github("Weecology/NeonTreeEvaluation_package")
+install_github("weecology/NeonTreeEvaluation_package")
 ```
 
 # Download sensor data


### PR DESCRIPTION
I know this currently works as is, just a minor tweak for consistency.